### PR TITLE
fix location of secret generation, manual user/password

### DIFF
--- a/charts/datahub/values.yaml
+++ b/charts/datahub/values.yaml
@@ -53,13 +53,13 @@ datahub-frontend:
   ingress:
     enabled: false
   defaultUserCredentials: {}
-  service:
-    extraLabels: {}
     # randomAdminPassword: true
     # You can also set specific passwords for default users
     # manualValues: |
     #   datahub:manualPassword
     #   initialViewer:manualPassword
+  service:
+    extraLabels: {}
   # Optionaly specify service type for datahub-frontend: LoadBalancer, ClusterIP or NodePort, by default: LoadBalancer
   # service:
   #   type: ClusterIP


### PR DESCRIPTION
place randomAdminPassword and manualValues under defaultUserCredentials to where they are expected to be

See user-secret template: https://github.com/kspyy/datahub-helm/blob/fix/defaultUserCredentials-fix/charts/datahub/subcharts/datahub-frontend/templates/user-secrets.yaml#L11-L14



## Checklist
- [ ] The PR conforms to DataHub's [Contributing Guideline](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md) (particularly [Commit Message Format](https://github.com/datahub-project/datahub/blob/master/docs/CONTRIBUTING.md#commit-message-format))
- [x] Links to related issues (if applicable)
- [ ] Tests for the changes have been added/updated (if applicable)
- [ ] Docs related to the changes have been added/updated (if applicable)
